### PR TITLE
Add Wire.h file for backwards compatibility

### DIFF
--- a/compatibility/Wire.h
+++ b/compatibility/Wire.h
@@ -1,0 +1,1 @@
+#include "i2c_t3.h"


### PR DESCRIPTION
Thanks for writing i2c_t3, it works a treat.

I'm currently trying to integrate it into my own project that uses CMake to control the toolchain. It would be really handy to add this file as it would mean other libraries could use the i2c_t3 lib without alteration if the compatibility folder is added to the include path.
