### PR TITLE
Squash warning from clang

### DIFF
--- a/i2c_t3.h
+++ b/i2c_t3.h
@@ -797,7 +797,7 @@ public:
 
     // ------------------------------------------------------------------------------------------------------
     // Immediate operation
-    static void i2c_wait_(struct i2cStruct* i2c) { while(!(*(i2c->S) & I2C_S_IICIF)); *(i2c->S) = I2C_S_IICIF; }
+    static void i2c_wait_(struct i2cStruct* i2c) { while(!(*(i2c->S) & I2C_S_IICIF)){} *(i2c->S) = I2C_S_IICIF; }
 };
 
 extern i2c_t3 Wire;


### PR DESCRIPTION
Clang warns about the empty statement following a while loop. This can be fixed by either putting a line break before the semicolon or using an empty compound statement.
