### PR TITLE
define I2C_AUTO_RETRY, added resetBusCountRead() of times resetBus ex…

### DIFF
--- a/examples/advanced_scanner/advanced_scanner.ino
+++ b/examples/advanced_scanner/advanced_scanner.ino
@@ -51,7 +51,7 @@ void setup()
 
     // Setup for Master mode, all buses, external pullups, 400kHz, 10ms default timeout
     //
-    Wire.begin(I2C_MASTER, 0x00, WIRE_PINS, I2C_PULLUP_EXT, 400000);
+    Wire.begin(I2C_MASTER, 0x00, WIRE_PINS, I2C_PULLUP_EXT, 100000);
     Wire.setDefaultTimeout(10000); // 10ms
     #if I2C_BUS_NUM >= 2
     Wire1.begin(I2C_MASTER, 0x00, WIRE1_PINS, I2C_PULLUP_EXT, 400000);

--- a/examples/basic_scanner/basic_scanner.ino
+++ b/examples/basic_scanner/basic_scanner.ino
@@ -25,7 +25,7 @@ void setup()
     pinMode(11,INPUT_PULLUP);       // pull pin 11 low for a more verbose result (shows both ACK and NACK)
 
     // Setup for Master mode, pins 18/19, external pullups, 400kHz, 10ms default timeout
-    Wire.begin(I2C_MASTER, 0x00, I2C_PINS_18_19, I2C_PULLUP_EXT, 400000);
+    Wire.begin(I2C_MASTER, 0x00, I2C_PINS_18_19, I2C_PULLUP_EXT, 100000);
     Wire.setDefaultTimeout(10000); // 10ms
 
     Serial.begin(115200);

--- a/i2c_t3.cpp
+++ b/i2c_t3.cpp
@@ -797,7 +797,7 @@ uint8_t i2c_t3::acquireBus_(struct i2cStruct* i2c, uint8_t bus, uint32_t timeout
             if(!(*(i2c->C1) & I2C_C1_MST))
             {
                 resetBus_(i2c,bus);
-                i2c->resetBusCount++;   // bboyes
+                if ((i2c->resetBusCount) < UINT32_MAX) i2c->resetBusCount++;   // bboyes max test added 2017Jun20
                 if(!(*(i2c->S) & I2C_S_BUSY))
                 {
                     // become the bus master in transmit mode (send start)

--- a/i2c_t3.cpp
+++ b/i2c_t3.cpp
@@ -272,6 +272,8 @@ void i2c_t3::begin_(struct i2cStruct* i2c, uint8_t bus, i2c_mode mode, uint8_t a
         *(i2c->C1) = I2C_C1_IICEN; // Master - enable I2C (hold in Rx mode, intr disabled)
     else
         *(i2c->C1) = I2C_C1_IICEN|I2C_C1_IICIE; // Slave - enable I2C and interrupts
+
+    i2c->resetBusCount = 0;   // bboyes
 }
 
 
@@ -795,6 +797,7 @@ uint8_t i2c_t3::acquireBus_(struct i2cStruct* i2c, uint8_t bus, uint32_t timeout
             if(!(*(i2c->C1) & I2C_C1_MST))
             {
                 resetBus_(i2c,bus);
+                i2c->resetBusCount++;   // bboyes
                 if(!(*(i2c->S) & I2C_S_BUSY))
                 {
                     // become the bus master in transmit mode (send start)

--- a/i2c_t3.h
+++ b/i2c_t3.h
@@ -204,7 +204,7 @@
 //
 // Note: this is incompatible with multi-master buses, only use in single-master configurations
 //
-//#define I2C_AUTO_RETRY
+#define I2C_AUTO_RETRY
 
 // ======================================================================================================
 // == End User Define Section ===========================================================================
@@ -424,6 +424,7 @@ struct i2cStruct
     void (*user_onRequest)(void);            // Slave Tx Callback Function        (User)
     DMAChannel* DMA;                         // DMA Channel object                (User&ISR)
     uint32_t defTimeout;                     // Default Timeout                   (User)
+    uint32_t resetBusCount;     // bboyes, times timeout and resetBus has been called
 };
 
 
@@ -475,6 +476,7 @@ private:
     #endif
 
 public:
+
     //
     // I2C bus number - this is a local, passed as an argument to base functions
     //                  since static functions cannot see it.
@@ -861,6 +863,12 @@ public:
     //         I2C_SLAVE_TX, I2C_SLAVE_RX
     //
     inline i2c_status status(void) { return i2c->currentStatus; }
+
+
+    // this makes a Wire.resetBusCountRead() but I'd rather have and instance function
+    //
+    inline uint32_t resetBusCountRead(void) { return i2c->resetBusCount; }  // bboyes
+
 
     // ------------------------------------------------------------------------------------------------------
     // Return Status (base routine)


### PR DESCRIPTION
Please Ignore the two changes of I2C clock speed (I don't know how to keep those out of a pull request). The other two are use of a resetBusCount, very minimal, adds no overhead to normal execution. I find it useful to know when auto retry has taken place and how many time the resetBus was needed. Thanks for a wonderful library!